### PR TITLE
Remove the retrospective text of the Jumbotron

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,7 @@
         <h1>StructureMap</h1>
         <p>
 StructureMap is the oldest, continuously used IoC/DI container for .Net dating back to its first public release and production usage all the way back in June 2004 on .Net 1.1.  
-The current 4.* release represents 12+ years of lessons learned in the StructureMap and greater .Net community -- while also wiping away a <b>great</b> deal of legacy design
-decisions that no longer make sense today.
+The current 4.* release represents 12+ years of lessons learned in the StructureMap and greater .Net community.
         </p>
         <p><a class="btn btn-primary btn-lg" href="/documentation" role="button">Learn more &raquo;</a></p>
       </div>


### PR DESCRIPTION
Removing "while also wiping away a <b>great</b> deal of legacy design decisions that no longer make sense today." ...

I fully understand that the developers like to vent the great wins in improving the code efficiency and design, but it isn't one of the unique selling points of StructureMap ... I feel this part of the website is better for such things, as in funneling the visitor into becoming a user by supplying attractive (selling), concise and helpful information about the software.
